### PR TITLE
Change E2 interface from single directional to bidirectional stream

### DIFF
--- a/protos/e2-interface.proto
+++ b/protos/e2-interface.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package interface.e2;
 
 service E2InterfaceService {
-    rpc UpdateAttribute (E2Message) returns (ServiceResult) {}
+    rpc Send (stream E2Message) returns (stream ServiceResult) {}
 
     // Can be extended if necessary
 }
@@ -68,9 +68,9 @@ enum E2MessageType {
 
 // Message header
 message E2MessageHeader {
-    string sourceID = 1;
-    string destinationID = 2;
-    E2MessageType messageType = 3;
+    E2MessageType messageType = 1;
+
+    // Can be extended if necessary
 }
 
 // Message payload; one of attributes defined below


### PR DESCRIPTION
For this, only add "stream" words on service on e2-interface.proto file in protos directory. It is no harm in E2 proxy and ric-api-gw, because I didn't update proto files in the E2 proxy and ric-api-gw. With this patch, E2 proxy and ric-api-gw (it is out-of-date) does not support bidirectional stream yet. However, I have been updating E2 proxy to enable bidirectional stream. New patches will follow to support it.